### PR TITLE
styling for link-account, home and modal

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -15,6 +15,7 @@
         "query-string": "^7.1.1",
         "stylus": "^0.55.0",
         "svelte": "^3.50.0",
+        "svelte-focus-trap": "^1.2.0",
         "svelte-preprocess": "^4.10.7",
         "svelte-router-spa": "^6.0.3",
         "vite": "^3.0.9",
@@ -4743,6 +4744,12 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
     },
+    "node_modules/mousetrap": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
+      "integrity": "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA==",
+      "dev": true
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -5887,6 +5894,15 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/svelte-focus-trap": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/svelte-focus-trap/-/svelte-focus-trap-1.2.0.tgz",
+      "integrity": "sha512-/hIUHgKcFlewsQreq8v7DYNBkQe7rR0c94PNBOCsmeUwoIYAy6iXJ1pH0k3rWpjwZHKtUxeXbX1iRFlFhipbeg==",
+      "dev": true,
+      "dependencies": {
+        "mousetrap": "^1.6.5"
       }
     },
     "node_modules/svelte-hmr": {
@@ -10226,6 +10242,12 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
     },
+    "mousetrap": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
+      "integrity": "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -11064,6 +11086,15 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.55.1.tgz",
       "integrity": "sha512-S+87/P0Ve67HxKkEV23iCdAh/SX1xiSfjF1HOglno/YTbSTW7RniICMCofWGdJJbdjw3S+0PfFb1JtGfTXE0oQ==",
       "dev": true
+    },
+    "svelte-focus-trap": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/svelte-focus-trap/-/svelte-focus-trap-1.2.0.tgz",
+      "integrity": "sha512-/hIUHgKcFlewsQreq8v7DYNBkQe7rR0c94PNBOCsmeUwoIYAy6iXJ1pH0k3rWpjwZHKtUxeXbX1iRFlFhipbeg==",
+      "dev": true,
+      "requires": {
+        "mousetrap": "^1.6.5"
+      }
     },
     "svelte-hmr": {
       "version": "0.15.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -19,6 +19,7 @@
     "query-string": "^7.1.1",
     "stylus": "^0.55.0",
     "svelte": "^3.50.0",
+    "svelte-focus-trap": "^1.2.0",
     "svelte-preprocess": "^4.10.7",
     "svelte-router-spa": "^6.0.3",
     "vite": "^3.0.9",

--- a/ui/src/modules/Home/Home.svelte
+++ b/ui/src/modules/Home/Home.svelte
@@ -8,8 +8,6 @@
   export let currentRoute // else Svelte complains (I don't know why yet)
   export let params // else Svelte complains (I don't know why yet)
 
-  let myName
-  
   function er(msg) { 
     ({ m0, m1 } = dlg('Alert', msg, 'OK', () => m0 = false)); m0=m0; m1=m1
     store.erMsg.set(null)
@@ -19,7 +17,6 @@
     store.qr.set(null) // no going back to previous customer
     const erMsg = await store.erMsg.get()
     if (erMsg) er(erMsg)
-    myName = $store.myAccount.name
   })
 </script>
 
@@ -30,13 +27,18 @@
 </svelte:head>
 
 <section id='home'>
-  <h2>{ myName }</h2>
   <h2>Ready to charge customers</h2>
   <a href='/scan'>Scan QR</a>
 </section>
 
 <style lang='stylus'>
+  section
+    height 100%
+    display flex
+    flex-direction column
+    align-items center
+    justify-content space-between
   a
     cgButton()
-    margin $s2 0 0
+    margin-bottom $s4
 </style>

--- a/ui/src/modules/LinkAccount/LinkAccount.styl
+++ b/ui/src/modules/LinkAccount/LinkAccount.styl
@@ -1,14 +1,14 @@
 linkAccountAction()
   cgButton()
-  margin $s2 0
+  margin-bottom $s4
 
 linkAccountContent()
   background $c-green
   border 1px solid $c-black
+  margin-bottom $s2
   padding $s2
   text-align center
 
   h1
     font-weight 600
-    margin-bottom $s1
     text lg

--- a/ui/src/modules/LinkAccount/LinkAccount.svelte
+++ b/ui/src/modules/LinkAccount/LinkAccount.svelte
@@ -2,7 +2,6 @@
   import queryString from 'query-string'
   import { onMount } from 'svelte'
   import store from '#store.js'
-  import { htmlQuote } from '#utils.js'
   import SelectAccount from './SelectAccount/SelectAccount.svelte'
   import Modal from '../Modal.svelte'; let m0, m1, m2
 // FAILS  import { page } from '$app/stores'
@@ -16,7 +15,6 @@
   let size
 
   let myAccount
-  let message
   let ready = false
   let accounts
     
@@ -27,7 +25,6 @@
   function gotAccount(ev) {
     myAccount = accounts[ev.detail]
     store.myAccount.set(myAccount)
-    message = 'This device is now linked' + htmlQuote(`to ${myAccount.name}.`)
   }
 
   onMount(async () => {
@@ -55,14 +52,12 @@
 <section id='link-account'>
   { #if ready }
     { #if myAccount }
-      <section id='link-account-automatic'>
         <div class='link-account-content'>
-          <h1>{@html message }</h1>
+          <h1>This account is now linked to <span>{$store.myAccount.name}</span></h1>
           <p>You are ready to charge customers!</p>
         </div>
 
         <a class='link-account-action' href='/scan'>Scan QR Code</a>
-      </section>
 
     { :else }
       <SelectAccount { accountOptions } { size } on:complete={ gotAccount } />
@@ -77,15 +72,24 @@
 <style lang='stylus'>
   @import './LinkAccount.styl'
 
-  #link-account
+  section
     display flex
     flex-direction column
     justify-content space-between
     width 100%
+    height 100%
 
-    .link-account-action
-      linkAccountAction()
+  h1
+    display flex
+    flex-direction column
+    margin-bottom $s4
+    span  
+      font-weight 400
+      margin $s1 0
 
-    .link-account-content
-      linkAccountContent()
+  .link-account-action
+    linkAccountAction()
+
+  .link-account-content
+    linkAccountContent()
 </style>

--- a/ui/src/modules/Modal.svelte
+++ b/ui/src/modules/Modal.svelte
@@ -1,5 +1,6 @@
 <script>
-  import { createEventDispatcher, onDestroy } from 'svelte'
+  import { createEventDispatcher, onDestroy, onMount } from 'svelte'
+  import { focusTrap } from 'svelte-focus-trap'
 
   export let m0
   let modal
@@ -14,20 +15,32 @@ $:  [lab1, lab2, zot] = (labels + ', ').split(', ')
   if (previously_focused) {
     onDestroy(() => {previously_focused.focus()})
   }
+
 </script>
 
 { #if show }
-  <div class="modal-background"></div>
+  <div class="modal-background" on:click={() => {show = false}}></div>
 
-  <div class="modal" role="dialog" aria-modal="true" bind:this={modal}>
-    <h2>{ title }</h2>
+  <div class="modal" role="dialog" aria-modal="true" bind:this={modal} use:focusTrap>
+    <h1>{ title }</h1>
     <p>{ text }</p>
-    <button on:click={ () => dispatch('m1') }>{ lab1 }</button>
-    <button on:click={ () => dispatch('m2') }>{ lab2 }</button>
+    <div class="buttons">
+      <button on:click={ () => dispatch('m1') }>{ lab1 }</button>
+      {#if lab2}
+        <button on:click={ () => dispatch('m2') }>{ lab2 }</button>
+      {/if}
+    </div>
   </div>
 { /if }
 
 <style lang='stylus'>
+  h1
+    text(lg)
+    margin-bottom $s1
+  
+  p
+    margin-bottom: $s2
+
   .modal-background
     position fixed
     top 0
@@ -49,8 +62,12 @@ $:  [lab1, lab2, zot] = (labels + ', ').split(', ')
     border-radius 1em
     background white
 
+  .buttons
+    display flex
+    justify-content space-between
+
   button
     cgButton()
-      width 40%
+    width 46%
 
 </style>

--- a/ui/src/modules/Root/LayoutIntro/LayoutIntro.svelte
+++ b/ui/src/modules/Root/LayoutIntro/LayoutIntro.svelte
@@ -8,18 +8,18 @@
 
 </script>
 
-<div id='layout-intro'>
-  <div id='layout-intro-content'>
+<div class='layout-intro'>
+  <div class='content'>
     <Route { currentRoute } />
   </div>
 </div>
 
 <style lang='stylus'>
-  #layout-intro
+  .layout-intro
     background $c-green
-    fullHeight()
+    min-height 100vh
 
-    #layout-intro-content
+    .content
       contentNarrow()
-      padding $s3
+      padding $s2
 </style>

--- a/ui/src/modules/Root/LayoutStep/LayoutStep.svelte
+++ b/ui/src/modules/Root/LayoutStep/LayoutStep.svelte
@@ -2,6 +2,7 @@
   import { Route } from 'svelte-router-spa'
   import cgLogo from '#modules/Root/assets/cg-logo-300.png?webp'
   import { navigateTo } from 'svelte-router-spa'
+  import store from '#store.js'
 
   export let params // else Svelte complains (I don't know why yet)
   export let currentRoute
@@ -9,31 +10,39 @@
   // --------------------------------------------
 </script>
 
-<div id='layout-step'>
+<div class='layout-step'>
   <header>
-    <div id='layout-step-header-content'>
       <img src={ cgLogo } alt='Common Good Logo' on:click={ () => navigateTo('/home') } />
-    </div>
+      {#if $store.myAccount.name}
+      <h2>{ $store.myAccount.name }</h2>
+      {/if}
   </header>
 
-  <div id='layout-step-content'>
+  <div class='content'>
     <Route { currentRoute } />
   </div>
 </div>
 
 <style lang='stylus'>
-  #layout-step
-    fullHeight()
+  .layout-step
+    contentNarrow()
+    height 100vh
     padding $s2
 
-    header
-      #layout-step-header-content
-        contentNarrow()
+  header
+    display flex
+    align-items center
+    margin-bottom: $s2
 
-        img
-          clampSize(20vw, 50px)
+  h2
+    width 100%
+    text-align center
+    text md
+    padding 0 $s1
 
-    #layout-step-content
-      contentNarrow()
-      margin $s2 auto
+  img
+    clampSize(20vw, 50px)
+
+  .content
+    height calc(100% - 50px)
 </style>

--- a/ui/src/styles/app.base.styl
+++ b/ui/src/styles/app.base.styl
@@ -11,4 +11,6 @@ html
     font-size 16px
 
 html, body, main
-  fullHeight()
+  height: 100%
+  width: 100%
+  margin: 0

--- a/ui/src/styles/app.support.styl
+++ b/ui/src/styles/app.support.styl
@@ -92,6 +92,3 @@ contentCentered(direction = row)
 contentNarrow(max = 500px)
   margin 0 auto
   max-width max
-
-fullHeight()
-  min-height 100vh

--- a/ui/src/utils.js
+++ b/ui/src/utils.js
@@ -63,8 +63,6 @@ async function timedFetch(url, options = {}) {
 
 function isTimeout(er) { return (er.name == 'AbortError') }
 
-function htmlQuote(s) { return `<pre>${s}</pre>` }
-
 /**
  * Filter an object by key and/or value (just like for an array)
  * @param {*} obj0 
@@ -116,4 +114,4 @@ function disableBack() {
         body: JSON.stringify(tx)
 */
 
-export { yesno, dlg, hash, goEr, goHome, CgError, timedFetch, isTimeout, htmlQuote, filterObjByKey, sendTxRequest }
+export { yesno, dlg, hash, goEr, goHome, CgError, timedFetch, isTimeout, filterObjByKey, sendTxRequest }


### PR DESCRIPTION
- Removed `<pre>` from Account Name to enable text wrapping (this was causing a problem on long names such as "Octopus Wordworking Academy")
- Replaced some styling against `id` attributes with styling against `class` (css best practice is to not style against ids. However, I left in `ids` that have functional dependencies)
- Updated content heights to position action buttons closer to the bottom of screen for better mobile usability (easier to press with thumb)
- Styled Modal
- Added focus trap (for a11y) and click to close functionality to modal