### PR TITLE
Bugfix/android screen height

### DIFF
--- a/ui/src/modules/Home/Home.svelte
+++ b/ui/src/modules/Home/Home.svelte
@@ -58,24 +58,22 @@
       <div class='watermark'>
         <img class='logo' src= { cgLogo } alt='Common Good Logo' />
         <p>CGPay v{ _version_ }</p>
-        <div><h1>&nbsp;</h1></div> <!-- to center the logo vertically -->
       </div>
     </div>
   { /if }
 
-  { #if $store.testMode }
-    <div class="fakes">
-      <button on:click={ () => fake('G6VM0RZzhWMCq0zcBowqw.') }>Susan</button>
-      <button on:click={ () => fake('HTTP://6VM.RC4.ME/G00WeHlioM5JZv1O9G') }>Maria</button>
-      <button on:click={ () => fake('HTTP://6VM.RC4.ME/H010WeHlioM5JZv1O9G') }>Store</button>
-      <button on:click={ () => fake('H6VM0G0NyCBBlUF1qWNZ2k.') }>Helga's</button>
-      <button on:click={ () => fake('HTTP://6VM.RC4.ME/H0G0NyCBBlUF1qWNZ2k') }>Helga2</button>
-      <button on:click={ () => fake('H6VM0G0NyCBBlUF.') }>Bad Online</button>
-      <button on:click={ () => fake('garbage.') }>Bad</button>
-    </div>
-  { /if }
-
   <div class="charge">
+    { #if $store.testMode }
+      <div class="fakes">
+        <button on:click={ () => fake('G6VM0RZzhWMCq0zcBowqw.') }>Susan</button>
+        <button on:click={ () => fake('HTTP://6VM.RC4.ME/G00WeHlioM5JZv1O9G') }>Maria</button>
+        <button on:click={ () => fake('HTTP://6VM.RC4.ME/H010WeHlioM5JZv1O9G') }>Store</button>
+        <button on:click={ () => fake('H6VM0G0NyCBBlUF1qWNZ2k.') }>Helga's</button>
+        <button on:click={ () => fake('HTTP://6VM.RC4.ME/H0G0NyCBBlUF1qWNZ2k') }>Helga2</button>
+        <button on:click={ () => fake('H6VM0G0NyCBBlUF.') }>Bad Online</button>
+        <button on:click={ () => fake('garbage.') }>Bad</button>
+      </div>
+    { /if }
     <a class="scan-customer" href='/scan'>Scan QR Code to Charge</a>
   </div>
 </section>
@@ -88,6 +86,7 @@
   .fakes
     display flex
     justify-content space-between
+    overflow-x scroll
 
   .fakes button
     cgButtonSecondary()
@@ -109,7 +108,7 @@
     margin-bottom $s2
 
   img 
-    width 250px
+    max-width 250px
 
   section
     height 100%
@@ -117,10 +116,6 @@
     flex-direction column
     align-items center
     justify-content space-between
-
-  .business
-    h1
-      margin-bottom $s5
 
   .top
     width 100%

--- a/ui/src/modules/SignIn/SignIn.svelte
+++ b/ui/src/modules/SignIn/SignIn.svelte
@@ -60,9 +60,9 @@
     <h2>Sign In</h2>
     <form on:submit|preventDefault={ signIn }>
       <label class='visuallyhidden' for='account-id'>Account ID or Email Address</label>
-      <input name='account-id' type='text' placeholder='Account ID or Email Address' autocomplete='name' bind:value={ credentials.identifier } required />
+      <input name='account-id' type='text' placeholder='Account ID or Email Address' autocomplete='name' autocapitalize='off' bind:value={ credentials.identifier } required />
       <label class='visuallyhidden' for='password'>Password</label>
-      <input type='password' placeholder='Password' autocomplete="current-password" bind:value={ credentials.password } required />
+      <input type='password' placeholder='Password' autocomplete='current-password' autocapitalize='off' bind:value={ credentials.password } required />
       <button type='submit'>Sign In</button>
     </form>
     <p class="status">{ statusMsg }</p>

--- a/ui/src/styles/app.base.styl
+++ b/ui/src/styles/app.base.styl
@@ -14,8 +14,7 @@ html, body, main
   margin: 0
 
 main
-  background $c-green
-  overflow: hidden
+  overflow-x hidden
 
 h1
   text(2xl)


### PR DESCRIPTION
This branch enables vertical scrolling as a potential (thought not ideal) workaround for the Android keyboard bug. 

It does not entirely correct the keyboard view bug (but I was also unable to reproduce it -- I reproduced an approximation on iOS)

A JavaScript workaround we could try: Add focus/blur event listeners on the inputs to either absolutely position them  or apply [scrollIntoView](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView). (referenced [here](https://stackoverflow.com/questions/71606355/pwa-does-not-resize-window-when-virtual-keyboard-is-active-on-fullscreen-display))

Two minor fixes included:
- Fixes autocapitalization on Safari for sign in inputs
- Moves the "fake" buttons so they don't add height to the overall screen (this was impeding my debugging)
