### PR TITLE
Two bugs fixed and a little simplification

### DIFF
--- a/src/modules/Charge.svelte
+++ b/src/modules/Charge.svelte
@@ -94,8 +94,8 @@
       testing = qr.includes('.RC4.')
     } else throw new Error('That is not a valid Common Good card format.')
 
-    if (testing && !$store.testMode) throw new Error('That is a real Common Good card and cannot be used in test mode.')
-    if (!testing && $store.testMode) throw new Error('That is a CGPay test card and cannot be used in production mode.')
+    if (!testing && $store.testMode) throw new Error('That is a real Common Good card and cannot be used in test mode.')
+    if (testing && !$store.testMode) throw new Error('That is a CGPay test card and cannot be used in production mode.')
 // NO. This risks our data integrity    if (testing != $store.testMode) changeMode(testing)
 
     const agentLen = +agentLens[dig36.indexOf(acct[0])]

--- a/src/store.js
+++ b/src/store.js
@@ -1,4 +1,4 @@
-import { get, writable } from 'svelte/store'
+import { writable } from 'svelte/store'
 import { postRequest, isTimeout } from '#utils.js'
 
 // --------------------------------------------
@@ -11,12 +11,6 @@ import { postRequest, isTimeout } from '#utils.js'
  * 
  * CONSTANTS
  *   bool testMode: true if the app is in test mode
- *   string origin: URL to run and install the app
- *   string api: application programming interface URL
- * 
- * CONSTANTS
- *   bool testMode: true if the app is in test mode
- *   string origin: URL to run and install the app
  *   string api: application programming interface URL
  * 
  * SCALARS
@@ -78,14 +72,14 @@ import { postRequest, isTimeout } from '#utils.js'
  */
 
 export const createStore = () => {
-  const mode = window.location.href.startsWith(_origins_.real) ? 'real' : 'test'
-  const storeKey = 'cgpay.' + mode
+  const mode = (window == undefined || window.location.href.includes('localhost')) ? 'dev'
+  : (window.location.href.startsWith(_productionUrl_) ? 'real' : 'test')
+  const storeKey = 'cgpay'
   const storedState = JSON.parse(window.localStorage.getItem(storeKey))
   const lostMsg = `Tell the customer "I'm sorry, that card is marked "LOST or STOLEN".`
 
   const defaults = {
-    testMode: (mode == 'test'),
-    origin: _origins_[mode],
+    testMode: (mode != 'real'),
     api: _apis_[mode],
     sawAdd: false,
     qr: null,
@@ -114,7 +108,7 @@ export const createStore = () => {
   let cache = { ...defaults, ...storedState }
   for (let k in cache) if (!(k in defaults)) delete cache[k]
   
-  const { zot, subscribe, update } = writable(cache)
+  const { subscribe, update } = writable(cache)
 
   // --------------------------------------------
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -54,7 +54,7 @@ function CgError(msg, name = 'CgError') { this.message = msg; this.name = name }
  */
 async function timedFetch(url, options = {}) {
   if (!store.inspect().online) throw new Error('offline') // this works for setWifiOff also
-  if (options.method == 'GET') url += '&version=' + _version_
+  if (options.method != 'POST') url += '&version=' + _version_
   const { timeout = 3000, type = 'json' } = options;
   const aborter = new AbortController();
   aborter.name = 'Timeout'

--- a/tests/cucumber.js
+++ b/tests/cucumber.js
@@ -1,8 +1,9 @@
 // cucumber.js
 let options = [
   'tests/features/**/*.feature',         // Specify our feature files
-  '--require tests/steps/**/*.js',       // Load step definitions
-  '--require tests/support/world.js',    // what to run before and after tests
+  '--import tests/steps/**/*.js',        // Load step definitions
+  '--import tests/support/**/*.js',      // load support definitions
+  '--import tests/world.js',             // what to run before and after tests
   '--format progress-bar',               // Load custom formatter
 //'--format @cucumber/pretty-formatter', // Load custom formatter (works, but it's nothing special)
   '--publish-quiet'                      // Suppress the "Share your Cucumber Report" message (see below)

--- a/tests/steps/package.json
+++ b/tests/steps/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,11 +12,9 @@ function js(s) { return JSON.stringify(s) }
 export default defineConfig({
   define: {
     _version_: js(version),
-    _origins_: js({
-      test: 'https://app1.commongood.earth', 
-      real: 'https://app.commongood.earth'
-    }),
+    __productionUrl_: js('https://app.commongood.earth'),
     _apis_: js({
+      dev:  'http://localhost/cgmembers-frame/cgmembers/api',
       test: 'https://demo.commongood.earth/api',
       real: 'https://new.commongood.earth/api'
     }),


### PR DESCRIPTION
. using a test card on production or vice versa now gives the proper error message . GET requests now properly include the version number