### PR TITLE
Work in progress

### DIFF
--- a/tests/features/sign-in.feature
+++ b/tests/features/sign-in.feature
@@ -8,6 +8,12 @@ Background:
 
 Rule: Users sign in to use the app
 
-Scenario: I sign in to CGPay
+Scenario: I sign in to CGPay for the first time
   When I sign in
-  Then ? I am directed to the homepage
+  And I have not set a linked account
+  Then ? I am on link account page
+
+Scenario: I sign in to CGPay after having a linked account
+  When I sign in
+  And I have a linked account
+  Then ? I am on page homepage

--- a/tests/steps/steps.js
+++ b/tests/steps/steps.js
@@ -52,3 +52,8 @@ Then('? the page title is {string}', async function (wantTitle) {
   expect(gotTitle).toEqual(wantTitle)
 })
 */
+
+When('I sign in', async function() {
+  putStore()
+
+})


### PR DESCRIPTION
@WilliamSpademan this feature is proving difficult to test as a distinct feature because we track `isSignedIn` and 'has a linked account' as one-in-the same in the app state.

Maybe we de-prioritize this test and use the link-account tests to cover this functionality. What do you think?