### PR TITLE
Fix/Adds Android instructions for blocked popups

### DIFF
--- a/src/modules/AddToHomeScreen.svelte
+++ b/src/modules/AddToHomeScreen.svelte
@@ -26,6 +26,7 @@
     <img src= { cgLogo } alt="Common Good logo" />
     <h1>Add to Home Screen</h1>
   </header>
+  <p class="intro">We recommend adding CGPay to your home screen for a full app experience.</p>
     { #if u.isApple() }
       <AppleInstructions { skip } />
     { /if }

--- a/src/modules/AndroidInstructions.svelte
+++ b/src/modules/AndroidInstructions.svelte
@@ -5,13 +5,25 @@
 
 <section class="content" data-testid='android-instructions'>
   <div class='top'>
+    <h2>Instructions</h2>
     { #if u.isChrome() }
-      <p>To add CGPay to your home screen:</p>
-        <li>Tap the banner below (it may take a few seconds to appear).</li>
-        <li>Wait for installation to complete.</li>
-        <li>Choose "Open CGPay" on the system menu.</li>
+      <ul>
+        <li>1. Tap the banner below (it may take a few seconds to appear).</li>
+        <li class="nested">
+          If you do not see a banner:
+          <ul>
+            <li>Tap the three-dot icon in the top right corner of your screen.</li>
+            <li>In the menu, scroll down and select "Add to Home screen".</li>
+          </ul>
+        </li>
+        <li>2. Wait for installation to complete.</li>
+        <li>3. Choose "Open CGPay" on the system menu.</li> 
+      </ul>    
     { :else }
-      <p>To add CGPay to your home screen, open Chrome and browse to cg4.us/app</p>
+      <ul>
+        <li>1. Open Chrome and browse to cgpay.commongood.earth.</li>
+        <li>2. You will be guided to add CGPay to your home screen.</li>
+      </ul>
     { /if }
   </div>
   <button data-testid="continue-button" on:click={ skip }>Continue</button>

--- a/src/modules/AppleInstructions.svelte
+++ b/src/modules/AppleInstructions.svelte
@@ -7,8 +7,7 @@
 
 <div class="content" data-testid='apple-instructions'>
   <div class='top'>
-    <!--p>To add CGPay to your home screen, tap the banner below.</p-->
-    <p>To add CGPay to your home screen:</p>
+    <h2>Instructions</h2>
     { #if u.isSafari() }
       <ul>
         <li>1. Tap the Share <span class="inline-icon"><ShareIcon class="icon" size={"1.25rem"} /></span> button.</li>
@@ -16,7 +15,10 @@
         <li>3. Then tap "Add".</li>
       </ul>
     { :else }
-      <p>Open Safari and browse to cg4.us/cgpay </p>
+    <ul>
+      <li>1. Open Safari and browse to cgpay.commongood.earth.</li>
+      <li>2. You will be guided to add CGPay to your home screen.</li>
+    </ul>
     { /if }
   </div>
   <button data-testid="continue-button" on:click={ skip }>Continue</button>

--- a/src/modules/LayoutIntro.svelte
+++ b/src/modules/LayoutIntro.svelte
@@ -23,6 +23,6 @@
   .container
     constrainWidth($tablet)
     height 100%
-    padding $s-1
+    padding $s-2
     margin 0 auto  
 </style>

--- a/src/styles/AddToHomeScreen.styl
+++ b/src/styles/AddToHomeScreen.styl
@@ -2,17 +2,21 @@ header
   display flex
   flex-direction column
   align-items center
-  margin-bottom $s2
+  margin-bottom $s0
 
 img
-  clampSize(20vw, 100px)
+  clampSize(16vw, 100px)
   margin-bottom $s0
 
 button
   cgButtonTertiary()
 
+h2
+  text(lg)
+  margin-bottom $s0
+
 p 
-  margin-bottom $s2
+  margin-bottom $s0
 
 li 
   margin-bottom $s0
@@ -25,7 +29,8 @@ li
   background $c-white
   box-shadow: 2px 2px 4px $c-gray-dark
   border-radius: 2%
-  padding $s1
+  padding $s0
+  overflow-y scroll
   
 .content
   height 100%
@@ -33,8 +38,20 @@ li
   flex-direction column
   justify-content space-between
 
+.intro
+  text-align center
+
+.nested
+  font-weight 600
+  margin $s-2 0
+  
+  ul
+    font-weight 400
+    list-style disc
+    margin $s-2 $s1 $s1
+
 .top
-  margin 0 $s0
+  margin 0 $s-2
   
 
   


### PR DESCRIPTION
- Adds instructions in case a user has pop-ups blocked on Android
- Corrects link in non-Chrome/Safari instructions (it was cg4.us)
- Adds text "We recommend adding CGPay to your home screen for a full app experience." to A2HS instructions.
- Minor styling cleanup to fit new instructions

![Screen Shot 2023-04-05 at 2 19 08 PM](https://user-images.githubusercontent.com/20799647/230169342-3e9d248b-39a3-4944-9b74-2b41540bd4b9.png)
